### PR TITLE
Add ratelimit state and expires to verify key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
-## v0.4.1 (Aug 2023) 
+## v0.4.2 (Aug 2023)
+
+### Additions
+
+- Add `RatelimitState` model.
+- Add `ratelimit` and `expires` fields to `ApiKeyVerification`.
+
+---
+
+## v0.4.1 (Aug 2023)
 
 ### Changes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "unkey.py"
-version = "0.4.1"
+version = "0.4.2"
 description = "An asynchronous Python SDK for unkey.dev."
 authors = ["Jonxslays"]
 license = "GPL-3.0-only"

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -9,9 +9,6 @@ import pytest
 from unkey import Serializer
 from unkey import models
 
-# from unittest import mock
-
-
 DictT = t.Dict[str, t.Any]
 
 serializer = Serializer()

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from os import walk
 
 import typing as t
 from datetime import datetime
@@ -199,6 +200,46 @@ def test_to_api_key(
     assert result == full_api_key
 
 
+####################
+# to_ratelimit_state
+####################
+
+
+def _raw_ratelimit_state() -> DictT:
+    return {
+        "limit": 100,
+        "remaining": 90,
+        "reset": 123,
+    }
+
+
+@pytest.fixture()
+def raw_ratelimit_state() -> DictT:
+    return _raw_ratelimit_state()
+
+
+def _full_ratelimit_state() -> models.RatelimitState:
+    model = models.RatelimitState()
+    model.limit = 100
+    model.remaining = 90
+    model.reset = 123
+    return model
+
+
+@pytest.fixture()
+def full_ratelimit_state() -> models.RatelimitState:
+    return _full_ratelimit_state()
+
+
+def test_to_ratelimit_state(
+    raw_ratelimit_state: DictT,
+    full_ratelimit_state: models.RatelimitState,
+) -> None:
+    result = serializer.to_ratelimit_state(raw_ratelimit_state)
+
+    assert result == full_ratelimit_state
+
+
 #########################
 # to_api_key_verification
 #########################
@@ -210,6 +251,8 @@ def _raw_api_key_verification() -> DictT:
         "owner_id": None,
         "meta": None,
         "remaining": None,
+        "ratelimit": _raw_ratelimit_state(),
+        "expires": 12345,
         "error": "some error",
         "code": "NOT_FOUND",
     }
@@ -226,6 +269,8 @@ def _full_api_key_verification() -> models.ApiKeyVerification:
     model.owner_id = None
     model.meta = None
     model.remaining = None
+    model.ratelimit = _full_ratelimit_state()
+    model.expires = 12345
     model.error = "some error"
     model.code = models.ErrorCode.NotFound
     return model

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-from os import walk
 
 import typing as t
 from datetime import datetime

--- a/unkey/__init__.py
+++ b/unkey/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Final
 
 __packagename__: Final[str] = "unkey.py"
-__version__: Final[str] = "0.4.1"
+__version__: Final[str] = "0.4.2"
 __author__: Final[str] = "Jonxslays"
 __copyright__: Final[str] = "2023-present Jonxslays"
 __description__: Final[str] = "An asynchronous Python SDK for unkey.dev."
@@ -61,6 +61,7 @@ __all__ = (
     "MissingRequiredArgument",
     "Ok",
     "Ratelimit",
+    "RatelimitState",
     "RatelimitType",
     "Result",
     "Route",

--- a/unkey/models/__init__.py
+++ b/unkey/models/__init__.py
@@ -15,5 +15,6 @@ __all__ = (
     "ErrorCode",
     "HttpResponse",
     "Ratelimit",
+    "RatelimitState",
     "RatelimitType",
 )

--- a/unkey/models/keys.py
+++ b/unkey/models/keys.py
@@ -8,7 +8,14 @@ from .base import BaseEnum
 from .base import BaseModel
 from .http import ErrorCode
 
-__all__ = ("ApiKey", "ApiKeyMeta", "ApiKeyVerification", "Ratelimit", "RatelimitType")
+__all__ = (
+    "ApiKey",
+    "ApiKeyMeta",
+    "ApiKeyVerification",
+    "Ratelimit",
+    "RatelimitState",
+    "RatelimitType",
+)
 
 
 class RatelimitType(BaseEnum):
@@ -107,8 +114,29 @@ class ApiKeyVerification(BaseModel):
     be ignored.
     """
 
+    expires: t.Optional[int]
+    """The unix epoch in milliseconds indicating when this key expires,
+    if it does."""
+
+    ratelimit: t.Optional[RatelimitState]
+    """The state of the ratelimit set on this key, if any."""
+
     code: t.Optional[ErrorCode]
     """The optional error code returned by the unkey api."""
 
     error: t.Optional[str]
     """The error message if the key was invalid."""
+
+
+@attrs.define(init=False, weakref_slot=False)
+class RatelimitState(BaseModel):
+    """The state of the ratelimit for a given key."""
+
+    limit: int
+    """The number of burstable requests allowed."""
+
+    remaining: int
+    """The remaining requests in this burst window."""
+
+    reset: int
+    """The unix timestamp in milliseconds until the next window."""

--- a/unkey/serializer.py
+++ b/unkey/serializer.py
@@ -81,7 +81,6 @@ class Serializer:
         model = models.RatelimitState()
         self._set_attrs(model, data, "reset", "limit", "remaining")
         return model
-        
 
     def to_api(self, data: DictT) -> models.Api:
         model = models.Api()

--- a/unkey/serializer.py
+++ b/unkey/serializer.py
@@ -68,12 +68,20 @@ class Serializer:
 
     def to_api_key_verification(self, data: DictT) -> models.ApiKeyVerification:
         model = models.ApiKeyVerification()
+        ratelimit = data.get("ratelimit")
+        model.ratelimit = self.to_ratelimit_state(ratelimit) if ratelimit else ratelimit
         model.code = models.ErrorCode.from_str_maybe(data.get("code", ""))
         self._set_attrs_cased(
-            model, data, "valid", "owner_id", "meta", "remaining", "error", maybe=True
+            model, data, "valid", "owner_id", "meta", "remaining", "error", "expires", maybe=True
         )
 
         return model
+
+    def to_ratelimit_state(self, data: DictT) -> models.RatelimitState:
+        model = models.RatelimitState()
+        self._set_attrs(model, data, "reset", "limit", "remaining")
+        return model
+        
 
     def to_api(self, data: DictT) -> models.Api:
         model = models.Api()


### PR DESCRIPTION
This PR adds a new model `RatelimitState` for the associated field `ratelimit` on the `ApiKeyVerification` model.

It also adds the missing `expires` field.

Closes #3 