### PR TITLE
Migrate to new API endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,16 @@
 
 ## v0.5.0 (Dec 2023)
 
+### Breaking Changes
+
+- `verify_key` now requires an `api_id` parameter.
+- `list_keys` no longer accepts the `offset` parameter.
+
 ### Additions
 
 - Add `Conflict` variant to `ErrorCode`.
 - Add `get_key` method to `KeyService`.
-- Add optional `api_id` parameter to `verify_key`. **This parameter will be
-  required in the future.**
+- Add `cursor` parameter to `list_keys`.
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Additions
 
 - Add `Conflict` variant to `ErrorCode`.
+- Add `get_key` method to `KeyService`
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Changelog
 
-## v0.4.4 (Dec 2023)
+## v0.5.0 (Dec 2023)
 
 ### Additions
 
 - Add `Conflict` variant to `ErrorCode`.
-- Add `get_key` method to `KeyService`
+- Add `get_key` method to `KeyService`.
+- Add optional `api_id` parameter to `verify_key`. **This parameter will be
+  required in the future.**
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 - Add `get_key` method to `KeyService`.
 - Add `cursor` parameter to `list_keys`.
 
+## Bugfixes
+
+- Fix invalid default used when ratelimit was not passed in `create_key`.
+
 ### Changes
 
 - Refactor internal routes to use new API endpoints.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v0.4.4 (Dec 2023)
+
+### Additions
+
+- Add `Conflict` variant to `ErrorCode`.
+
+### Changes
+
+- Refactor internal routes to use new API endpoints.
+
+---
+
 ## v0.4.3 (Sep 2023)
 
 ### Additions
@@ -9,6 +21,8 @@
 ### Changes
 
 - Rename `UsageExceeded` error code to `KeyUsageExceeded`.
+
+---
 
 ## v0.4.2 (Aug 2023)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "unkey.py"
-version = "0.4.3"
+version = "0.5.0"
 description = "An asynchronous Python SDK for unkey.dev."
 authors = ["Jonxslays"]
 license = "GPL-3.0-only"

--- a/tests/services/test_http.py
+++ b/tests/services/test_http.py
@@ -13,6 +13,8 @@ def test_init() -> None:
     assert http._api_version == "/v1"  # type: ignore
     assert http._base_url == constants.API_BASE_URL  # type: ignore
     assert http._headers == {  # type: ignore
+        "Unkey-SDK": constants.USER_AGENT,
+        "User-Agent": constants.USER_AGENT,
         "x-user-agent": constants.USER_AGENT,
         "Authorization": "Bearer abc123",
     }
@@ -32,6 +34,8 @@ def test_full_init() -> None:
     assert http._api_version == "/v4"  # type: ignore
     assert http._base_url == "1234"  # type: ignore
     assert http._headers == {  # type: ignore
+        "Unkey-SDK": constants.USER_AGENT,
+        "User-Agent": constants.USER_AGENT,
         "x-user-agent": constants.USER_AGENT,
         "Authorization": "Bearer abc123",
     }

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -399,7 +399,7 @@ def test_to_api_key_meta(
 
 
 def _raw_api_key_list() -> DictT:
-    return {"total": 1, "keys": [_raw_api_key_meta()]}
+    return {"cursor": None, "total": 1, "keys": [_raw_api_key_meta()]}
 
 
 @pytest.fixture()
@@ -409,6 +409,7 @@ def raw_api_key_list() -> DictT:
 
 def _full_api_key_list() -> models.ApiKeyList:
     model = models.ApiKeyList()
+    model.cursor = None
     model.total = 1
     model.keys = [_full_api_key_meta()]
     return model

--- a/unkey/__init__.py
+++ b/unkey/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Final
 
 __packagename__: Final[str] = "unkey.py"
-__version__: Final[str] = "0.4.3"
+__version__: Final[str] = "0.5.0"
 __author__: Final[str] = "Jonxslays"
 __copyright__: Final[str] = "2023-present Jonxslays"
 __description__: Final[str] = "An asynchronous Python SDK for unkey.dev."

--- a/unkey/constants.py
+++ b/unkey/constants.py
@@ -7,7 +7,7 @@ import unkey
 __all__ = ()
 
 API_BASE_URL: Final[str] = "https://api.unkey.dev"
-USER_AGENT: Final[str] = f"unkey.py v{unkey.__version__}"
+USER_AGENT: Final[str] = f"unkey.py@v{unkey.__version__}"
 
 GET: Final[str] = "GET"
 PUT: Final[str] = "PUT"

--- a/unkey/models/apis.py
+++ b/unkey/models/apis.py
@@ -28,6 +28,9 @@ class Api(BaseModel):
 class ApiKeyList(BaseModel):
     """Data representing keys for an api."""
 
+    cursor: t.Optional[str]
+    """The cursor indicating the last key that was returned."""
+
     keys: t.List[ApiKeyMeta]
     """A list of keys associated with the api."""
 

--- a/unkey/models/http.py
+++ b/unkey/models/http.py
@@ -21,6 +21,7 @@ class ErrorCode(BaseEnum):
     InvalidKeyType = "INVALID_KEY_TYPE"
     NotUnique = "NOT_UNIQUE"
     Unknown = "UNKNOWN"
+    Conflict = "CONFLICT"
 
 
 @attrs.define(weakref_slot=False)

--- a/unkey/routes.py
+++ b/unkey/routes.py
@@ -88,4 +88,4 @@ UPDATE_KEY: t.Final[Route] = Route(c.POST, "/keys.updateKey")
 
 # Apis
 GET_API: t.Final[Route] = Route(c.GET, "/apis.getApi")
-GET_KEYS: t.Final[Route] = Route(c.GET, "/apis/{}/keys")
+GET_KEYS: t.Final[Route] = Route(c.GET, "/apis.listKeys")

--- a/unkey/routes.py
+++ b/unkey/routes.py
@@ -81,7 +81,8 @@ class Route:
 
 # Keys
 CREATE_KEY: t.Final[Route] = Route(c.POST, "/keys.createKey")
-VERIFY_KEY: t.Final[Route] = Route(c.POST, "/keys/verify")
+VERIFY_KEY: t.Final[Route] = Route(c.POST, "/keys.verifyKey")
+VERIFY_KEY_DEPRECATED: t.Final[Route] = Route(c.POST, "/keys/verify")
 REVOKE_KEY: t.Final[Route] = Route(c.DELETE, "/keys/{}")
 UPDATE_KEY: t.Final[Route] = Route(c.PUT, "/keys/{}")
 

--- a/unkey/routes.py
+++ b/unkey/routes.py
@@ -87,5 +87,5 @@ REVOKE_KEY: t.Final[Route] = Route(c.POST, "/keys.deleteKey")
 UPDATE_KEY: t.Final[Route] = Route(c.POST, "/keys.updateKey")
 
 # Apis
-GET_API: t.Final[Route] = Route(c.GET, "/apis/{}")
+GET_API: t.Final[Route] = Route(c.GET, "/apis.getApi")
 GET_KEYS: t.Final[Route] = Route(c.GET, "/apis/{}/keys")

--- a/unkey/routes.py
+++ b/unkey/routes.py
@@ -82,7 +82,6 @@ class Route:
 # Keys
 CREATE_KEY: t.Final[Route] = Route(c.POST, "/keys.createKey")
 VERIFY_KEY: t.Final[Route] = Route(c.POST, "/keys.verifyKey")
-VERIFY_KEY_DEPRECATED: t.Final[Route] = Route(c.POST, "/keys/verify")
 REVOKE_KEY: t.Final[Route] = Route(c.POST, "/keys.deleteKey")
 UPDATE_KEY: t.Final[Route] = Route(c.POST, "/keys.updateKey")
 

--- a/unkey/routes.py
+++ b/unkey/routes.py
@@ -80,7 +80,7 @@ class Route:
 
 
 # Keys
-CREATE_KEY: t.Final[Route] = Route(c.POST, "/keys")
+CREATE_KEY: t.Final[Route] = Route(c.POST, "/keys.createKey")
 VERIFY_KEY: t.Final[Route] = Route(c.POST, "/keys/verify")
 REVOKE_KEY: t.Final[Route] = Route(c.DELETE, "/keys/{}")
 UPDATE_KEY: t.Final[Route] = Route(c.PUT, "/keys/{}")

--- a/unkey/routes.py
+++ b/unkey/routes.py
@@ -83,7 +83,7 @@ class Route:
 CREATE_KEY: t.Final[Route] = Route(c.POST, "/keys.createKey")
 VERIFY_KEY: t.Final[Route] = Route(c.POST, "/keys.verifyKey")
 VERIFY_KEY_DEPRECATED: t.Final[Route] = Route(c.POST, "/keys/verify")
-REVOKE_KEY: t.Final[Route] = Route(c.DELETE, "/keys/{}")
+REVOKE_KEY: t.Final[Route] = Route(c.POST, "/keys.deleteKey")
 UPDATE_KEY: t.Final[Route] = Route(c.POST, "/keys.updateKey")
 
 # Apis

--- a/unkey/routes.py
+++ b/unkey/routes.py
@@ -84,6 +84,7 @@ CREATE_KEY: t.Final[Route] = Route(c.POST, "/keys.createKey")
 VERIFY_KEY: t.Final[Route] = Route(c.POST, "/keys.verifyKey")
 REVOKE_KEY: t.Final[Route] = Route(c.POST, "/keys.deleteKey")
 UPDATE_KEY: t.Final[Route] = Route(c.POST, "/keys.updateKey")
+GET_KEY: t.Final[Route] = Route(c.GET, "/keys.getKey")
 
 # Apis
 GET_API: t.Final[Route] = Route(c.GET, "/apis.getApi")

--- a/unkey/routes.py
+++ b/unkey/routes.py
@@ -84,7 +84,7 @@ CREATE_KEY: t.Final[Route] = Route(c.POST, "/keys.createKey")
 VERIFY_KEY: t.Final[Route] = Route(c.POST, "/keys.verifyKey")
 VERIFY_KEY_DEPRECATED: t.Final[Route] = Route(c.POST, "/keys/verify")
 REVOKE_KEY: t.Final[Route] = Route(c.DELETE, "/keys/{}")
-UPDATE_KEY: t.Final[Route] = Route(c.PUT, "/keys/{}")
+UPDATE_KEY: t.Final[Route] = Route(c.POST, "/keys.updateKey")
 
 # Apis
 GET_API: t.Final[Route] = Route(c.GET, "/apis/{}")

--- a/unkey/serializer.py
+++ b/unkey/serializer.py
@@ -118,6 +118,7 @@ class Serializer:
 
     def to_api_key_list(self, data: DictT) -> models.ApiKeyList:
         model = models.ApiKeyList()
+        model.cursor = data.get("cursor")
         model.total = data["total"]
         model.keys = [self.to_api_key_meta(key) for key in data["keys"]]
         return model

--- a/unkey/services/apis.py
+++ b/unkey/services/apis.py
@@ -30,7 +30,8 @@ class ApiService(BaseService):
         Returns:
             A result containing the requested information or an error.
         """
-        route = routes.GET_API.compile(api_id)
+        params = self._generate_map(apiId=api_id)
+        route = routes.GET_API.compile().with_params(params)
         data = await self._http.fetch(route)
 
         if isinstance(data, models.HttpResponse):

--- a/unkey/services/apis.py
+++ b/unkey/services/apis.py
@@ -53,8 +53,8 @@ class ApiService(BaseService):
         api_id: str,
         *,
         owner_id: UndefinedOr[str] = UNDEFINED,
-        limit: int = 100,
-        offset: int = 0,
+        limit: UndefinedOr[int] = UNDEFINED,
+        cursor: UndefinedOr[str] = UNDEFINED,
     ) -> ResultT[models.ApiKeyList]:
         """Gets a paginated list of keys for the given api.
 
@@ -64,15 +64,14 @@ class ApiService(BaseService):
         Keyword Args:
             owner_id: The optional owner id to list the keys for.
 
-            limit: The max number of keys to include in this page.
-                Defaults to 100.
+            limit: The optional max number of keys to include in this page.
 
-            offset: How many keys to offset by, for pagination.
+            cursor: Optional key used to determine pagination offset.
 
         Returns:
             A result containing api key list or an error.
         """
-        params = self._generate_map(apiId=api_id, ownerId=owner_id, limit=limit, offset=offset)
+        params = self._generate_map(apiId=api_id, ownerId=owner_id, limit=limit, cursor=cursor)
         route = routes.GET_KEYS.compile().with_params(params)
         data = await self._http.fetch(route)
 

--- a/unkey/services/apis.py
+++ b/unkey/services/apis.py
@@ -41,8 +41,8 @@ class ApiService(BaseService):
             return result.Err(
                 models.HttpResponse(
                     404,
-                    data["error"],
-                    models.ErrorCode.from_str_maybe(data.get("code", "unknown")),
+                    data["error"].get("message", "Unknown error"),
+                    models.ErrorCode.from_str_maybe(data["error"].get("code", "UNKNOWN")),
                 )
             )
 
@@ -82,8 +82,8 @@ class ApiService(BaseService):
             return result.Err(
                 models.HttpResponse(
                     404,
-                    data["error"],
-                    models.ErrorCode.from_str_maybe(data.get("code", "unknown")),
+                    data["error"].get("message", "Unknown error"),
+                    models.ErrorCode.from_str_maybe(data["error"].get("code", "UNKNOWN")),
                 )
             )
 

--- a/unkey/services/apis.py
+++ b/unkey/services/apis.py
@@ -72,8 +72,8 @@ class ApiService(BaseService):
         Returns:
             A result containing api key list or an error.
         """
-        params = self._generate_map(ownerId=owner_id, limit=limit, offset=offset)
-        route = routes.GET_KEYS.compile(api_id).with_params(params)
+        params = self._generate_map(apiId=api_id, ownerId=owner_id, limit=limit, offset=offset)
+        route = routes.GET_KEYS.compile().with_params(params)
         data = await self._http.fetch(route)
 
         if isinstance(data, models.HttpResponse):

--- a/unkey/services/http.py
+++ b/unkey/services/http.py
@@ -43,6 +43,8 @@ class HttpService:
             raise ValueError("Api key must be provided.")
 
         self._headers = {
+            "Unkey-SDK": constants.USER_AGENT,
+            "User-Agent": constants.USER_AGENT,
             "x-user-agent": constants.USER_AGENT,
             "Authorization": f"Bearer {api_key}",
         }

--- a/unkey/services/keys.py
+++ b/unkey/services/keys.py
@@ -225,4 +225,5 @@ class KeyService(BaseService):
                     models.ErrorCode.from_str_maybe(data["error"].get("code", "UNKNOWN")),
                 )
             )
+
         return result.Ok(self._serializer.to_api_key_meta(data))

--- a/unkey/services/keys.py
+++ b/unkey/services/keys.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 import typing as t
 
 from unkey import errors
@@ -95,17 +96,36 @@ class KeyService(BaseService):
 
         return result.Ok(self._serializer.to_api_key(data))
 
-    async def verify_key(self, key: str) -> ResultT[models.ApiKeyVerification]:
+    async def verify_key(
+        self, key: str, api_id: UndefinedOr[str] = UNDEFINED
+    ) -> ResultT[models.ApiKeyVerification]:
         """Verifies a key is valid and within ratelimit.
+
+        ### Warning
+
+            Using this method without the `api_id` parameter is deprecated as
+            of v0.5.0 and may result in an error in a future release.
 
         Args:
             key: The key to verify.
 
+            api_id: The (optional for now) api id to verify the key against.
+
         Returns:
             A result containing the api key verification or an error.
         """
-        route = routes.VERIFY_KEY.compile()
-        payload = self._generate_map(key=key)
+        if api_id is UNDEFINED:
+            route = routes.VERIFY_KEY_DEPRECATED.compile()
+            print(
+                "DEPRECATION WARNING: Verifying keys without passing `api_id` "
+                "is deprecated, and will no longer work in a future version. "
+                "Please provide the api id when you are verifying keys.",
+                file=sys.stderr,
+            )
+        else:
+            route = routes.VERIFY_KEY.compile()
+
+        payload = self._generate_map(key=key, apiId=api_id)
         data = await self._http.fetch(route, payload=payload)
 
         if isinstance(data, models.HttpResponse):

--- a/unkey/services/keys.py
+++ b/unkey/services/keys.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import sys
 import typing as t
 
 from unkey import errors
@@ -96,35 +95,18 @@ class KeyService(BaseService):
 
         return result.Ok(self._serializer.to_api_key(data))
 
-    async def verify_key(
-        self, key: str, api_id: UndefinedOr[str] = UNDEFINED
-    ) -> ResultT[models.ApiKeyVerification]:
+    async def verify_key(self, key: str, api_id: str) -> ResultT[models.ApiKeyVerification]:
         """Verifies a key is valid and within ratelimit.
-
-        ### Warning
-
-            Using this method without the `api_id` parameter is deprecated as
-            of v0.5.0 and may result in an error in a future release.
 
         Args:
             key: The key to verify.
 
-            api_id: The (optional for now) api id to verify the key against.
+            api_id: The id of the api to verify the key against.
 
         Returns:
             A result containing the api key verification or an error.
         """
-        if api_id is UNDEFINED:
-            route = routes.VERIFY_KEY_DEPRECATED.compile()
-            print(
-                "DEPRECATION WARNING: Verifying keys without passing `api_id` "
-                "is deprecated, and will no longer work in a future version. "
-                "Please provide the api id when you are verifying keys.",
-                file=sys.stderr,
-            )
-        else:
-            route = routes.VERIFY_KEY.compile()
-
+        route = routes.VERIFY_KEY.compile()
         payload = self._generate_map(key=key, apiId=api_id)
         data = await self._http.fetch(route, payload=payload)
 

--- a/unkey/services/keys.py
+++ b/unkey/services/keys.py
@@ -78,7 +78,7 @@ class KeyService(BaseService):
             remaining=remaining,
             byteLength=byte_length,
             expires=self._expires_in(milliseconds=expires or 0),
-            ratelimit=None
+            ratelimit=UNDEFINED
             if not ratelimit
             else self._generate_map(
                 limit=ratelimit.limit,

--- a/unkey/services/keys.py
+++ b/unkey/services/keys.py
@@ -198,7 +198,7 @@ class KeyService(BaseService):
         if all_undefined(name, owner_id, meta, expires, remaining, ratelimit):
             raise errors.MissingRequiredArgument("At least one value is required to be updated.")
 
-        route = routes.UPDATE_KEY.compile(key_id)
+        route = routes.UPDATE_KEY.compile()
         payload = self._generate_map(
             name=name,
             meta=meta,
@@ -207,7 +207,7 @@ class KeyService(BaseService):
             remaining=remaining,
             ratelimit=ratelimit,
             expires=self._expires_in(milliseconds=expires or 0)
-            if expires is not None
+            if expires is not UNDEFINED
             else expires,
         )
 

--- a/unkey/services/keys.py
+++ b/unkey/services/keys.py
@@ -142,8 +142,9 @@ class KeyService(BaseService):
         Returns:
             A result containing the http response or an error.
         """
-        route = routes.REVOKE_KEY.compile(key_id)
-        data = await self._http.fetch(route)
+        route = routes.REVOKE_KEY.compile()
+        payload = self._generate_map(keyId=key_id)
+        data = await self._http.fetch(route, payload=payload)
 
         if isinstance(data, models.HttpResponse):
             return result.Err(data)


### PR DESCRIPTION
This PR updates the SDK to use the new RPC style endpoints.

Adds in the `Unkey-SDK` header, and regular `User-Agent` header, instead of just `x-user-agent`.

Also fixed up error handling as the error responses returned by the API changed shape.

Closes #6