### PR TITLE
Fix race condition in `protected` decorator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## v0.7.2 (May 2024)
+
+### Fixes
+
+- Fix race condition for concurrent requests using the `protected` decorator.
+
+### Additions
+
+- The `Client` can now be used as an async context manager which starts
+  and closes the client automatically.
+
+### Changes
+
+- The `InvalidKeyHandlerT` and `ExcHandlerT` types no longer include `Optional`,
+  and instead are wrapped in `Optional` in the function signature.
+
+---
+
 ## v0.7.1 (Feb 2024)
 
 ### Fixes

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import functools
+import platform
 from typing import Callable
 from pathlib import Path
 
@@ -75,10 +76,15 @@ def types(session: nox.Session) -> None:
 
 
 @nox.session(reuse_venv=True)
-@install("black", "len8")
+@install("black")
 def formatting(session: nox.Session) -> None:
     session.run("black", ".", "--check")
-    session.run("len8")
+
+    major, minor, *_ = platform.python_version_tuple()
+    if major == "3" and int(minor) < 12:
+        # This is a hack but it doesnt support python 3.12
+        session.install(DEPS["len8"])
+        session.run("len8")
 
 
 @nox.session(reuse_venv=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "unkey.py"
-version = "0.7.1"
+version = "0.7.2"
 description = "An asynchronous Python SDK for unkey.dev."
 authors = ["Jonxslays"]
 license = "GPL-3.0-only"

--- a/unkey/__init__.py
+++ b/unkey/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Final
 
 __packagename__: Final[str] = "unkey.py"
-__version__: Final[str] = "0.7.1"
+__version__: Final[str] = "0.7.2"
 __author__: Final[str] = "Jonxslays"
 __copyright__: Final[str] = "2023-present Jonxslays"
 __description__: Final[str] = "An asynchronous Python SDK for unkey.dev."

--- a/unkey/client.py
+++ b/unkey/client.py
@@ -51,6 +51,13 @@ class Client:
 
         return service(self._http, self._serializer)  # type: ignore[return-value]
 
+    async def __aenter__(self) -> Client:
+        await self.start()
+        return self
+
+    async def __aexit__(self, *_args: t.Any, **_kwargs: t.Any) -> None:
+        await self.close()
+
     @property
     def keys(self) -> services.KeyService:
         """The key service used to make key related requests."""


### PR DESCRIPTION
This PR fixes a race condition in the `protected` decorator, which was caused by using a single client, starting and then closing the session, while concurrent requests were coming in.

Removed the optionality on handler types.

Added the ability to use the client as an async context manager.

Resolves #12 
Resolves #13 